### PR TITLE
Update command_tools.py

### DIFF
--- a/pyxrf/model/command_tools.py
+++ b/pyxrf/model/command_tools.py
@@ -234,7 +234,6 @@ def fit_pixel_data_and_save(
                 dataset_name="dataset_fit",  # Sum of all detectors: should end with '_fit'
                 quant_norm=quant_norm,
                 param_quant_analysis=param_quant_analysis,
-                distance_to_sample=quant_distance_to_sample,
                 dataset_dict=dataset,
                 positions_dict=positions_dict,
                 file_format="txt",


### PR DESCRIPTION
Removed distance_to_sample=quant_distance_to_sample from the definition "fit_pixel_data_and_save" call to "output_data" when save_txt == True. This fixes the bug that gives the error "TypeError: output_data() got an unexpected keyword argument 'distance_to_sample'"